### PR TITLE
Add cucumber support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ In your Gemfile simply replace `capybara-screenshot` with `capybara-inline-scree
 gem 'capybara-inline-screenshot'
 ```
 
+
+### RSpec
+
 And where you initialize Capybara simply replace your call to:
 
 ```ruby
@@ -28,6 +31,14 @@ with:
 
 ```ruby
 require 'capybara-inline-screenshot/rspec'
+```
+
+### Cucumber
+
+For cucumber we use a different file
+
+```ruby
+require 'capybara-inline-screenshot/cucumber'
 ```
 
 The final step is to configure your build steps to upload the screenshot artifacts. The default path is your app’s `tmp` directory, so the artifact upload pattern would be `tmp/*.png`

--- a/lib/capybara-inline-screenshot/cucumber.rb
+++ b/lib/capybara-inline-screenshot/cucumber.rb
@@ -1,0 +1,25 @@
+require 'capybara-inline-screenshot'
+require 'capybara-screenshot'
+
+Before do |scenario|
+  Capybara::Screenshot.final_session_name = nil
+end
+
+After do |scenario|
+  if Capybara::Screenshot.autosave_on_failure && scenario.failed?
+    Capybara.using_session(Capybara::Screenshot.final_session_name) do
+      filename_prefix = Capybara::Screenshot.filename_prefix_for(:cucumber, scenario)
+
+      saver = Capybara::Screenshot::Saver.new(Capybara, Capybara.page, true, filename_prefix)
+      saver.save
+      saver.output_screenshot_path
+
+      if File.exist?(saver.screenshot_path)
+        encoded_img = CapybaraInlineScreenshot.inline_base64(File.read(saver.screenshot_path))
+        embed(encoded_img, 'image/png;base64', "Screenshot of the error")
+
+        STDOUT.puts CapybaraInlineScreenshot.escape_code_for_image(saver.screenshot_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This file is based off the version available in the capybara-screenshot
gem here:
https://github.com/mattheworiordan/capybara-screenshot/blob/850846ea32/lib/capybara-screenshot/cucumber.rb

I've simply added the line to print out the inlined image. NOTE: We need
to use `STDOUT.puts` instead of simply `puts` to ensure the output
buffer is correctly flushed, without this the image is not inline
printed in CI.
