### PR TITLE
Only use rails root if it exists when setting @base_artifact_dir.

### DIFF
--- a/lib/capybara-inline-screenshot.rb
+++ b/lib/capybara-inline-screenshot.rb
@@ -10,7 +10,7 @@ module CapybaraInlineScreenshot
   end
 
   def self.base_artifact_dir
-    @base_artifact_dir || Rails.root
+    @base_artifact_dir || (Rails.root if defined? Rails)
   end
 
   def self.escape_code_for_image(path)


### PR DESCRIPTION
This allows for the use of this tool outside of Rails.