### PR TITLE
Resolve Cucumber v4 deprecation warning

### DIFF
--- a/lib/capybara-inline-screenshot/cucumber.rb
+++ b/lib/capybara-inline-screenshot/cucumber.rb
@@ -16,7 +16,8 @@ After do |scenario|
 
       if File.exist?(saver.screenshot_path)
         encoded_img = CapybaraInlineScreenshot.inline_base64(File.read(saver.screenshot_path))
-        embed(encoded_img, 'image/png;base64', "Screenshot of the error")
+        method = respond_to?(:attach) ? :attach : :embed
+        send(method, encoded_img, 'image/png;base64')
 
         STDOUT.puts CapybaraInlineScreenshot.escape_code_for_image(saver.screenshot_path)
       end


### PR DESCRIPTION
### Context

[Cucumber version 4](https://rubygems.org/gems/cucumber/versions/4.0.0) has recently been released. In this new version the `embed` method has been [deprecated in favour](https://github.com/cucumber/cucumber-ruby/blob/v4.0.0/lib/cucumber/glue/proto_world.rb#L100-L108) of the new `attach` method.

When the `capybara-inline-screenshot` produces a screenshot it results in this garish deprecation warning:

```
WARNING: #embed(file, mime_type, label) is deprecated and will be removed after version 5.0.0. Please use attach(file, media_type) instead.
(Called from /usr/local/bundle/ruby/2.6.0/gems/capybara-inline-screenshot-2.2.0/lib/capybara-inline-screenshot/cucumber.rb:19:in `block (2 levels) in <top (required)>')
```

### Change

Use the `attach` method where available, instead of the `embed` method.

### Considerations

I've tested this change with both Cucumber 3.2.0 and 4.0.1. In both scenarios screenshots are successfully included in the Buildkite logs.
